### PR TITLE
Teleport menu.

### DIFF
--- a/gamemodes/SS/Core/Admin/Level2.pwn
+++ b/gamemodes/SS/Core/Admin/Level2.pwn
@@ -14,6 +14,7 @@ hook OnGameModeInit()
 	RegisterAdminCommand(ADMIN_LEVEL_MOD, "/banlist - show list of bans\n");
 	RegisterAdminCommand(ADMIN_LEVEL_MOD, "/banned - check if banned\n");
 	RegisterAdminCommand(ADMIN_LEVEL_MOD, "/setmotd - set message of the day\n");
+	RegisterAdminCommand(ADMIN_LEVEL_MOD, "/tpmenu - opens a teleport menu.\n");
 }
 
 
@@ -353,7 +354,7 @@ ACMD:setmotd[2](playerid, params[])
 	Teleport around the world menu ( Core : TMenuCore.pwn )
 
 ==============================================================================*/
-
+#include "../SS/Core/Admin/TMenuCore.pwn"
 ACMD:tpmenu[2](playerid, params[])
 {
 	new targetid,

--- a/gamemodes/SS/Core/Admin/Level2.pwn
+++ b/gamemodes/SS/Core/Admin/Level2.pwn
@@ -347,3 +347,33 @@ ACMD:setmotd[2](playerid, params[])
 
 	return 1;
 }
+
+/*==============================================================================
+
+	Teleport around the world menu ( Core : TMenuCore.pwn )
+
+==============================================================================*/
+
+ACMD:tpmenu[2](playerid, params[])
+{
+	new targetid,
+ 		
+	if(!(IsPlayerOnAdminDuty(playerid)))
+		return 6;
+		
+	if(!sscanf(params, "r", targetid)) // if you trust a player and you don't have time to
+	{                                  // teleport yourself then /get.
+	    if (toplayerid != INVALID_PLAYER_ID){
+	    	strcat(name, params);
+	    	MsgF(playerid, YELLOW, ">  Teleport Menu Opened to: %P",targetid);
+	    	Msg(targetid, YELLOW, ">  Teleport Menu Opened.");
+			TMCShowDialog(targetid);
+			return 1;}
+		else{
+			SendClientMessage(playerid, 0xFF0000FF, "That player is not connected.");
+			return 1;}
+	}
+	
+	TMCShowDialog(playerid); // Teleport yourself then get player to you. ( /get )
+	return 1;
+}


### PR DESCRIPTION
- Teleport menu to let admins travel in the world easily.
- I got teleported to Whitehouse a couple times and I don't like wasting a lot of admin's time so I made this to simplify their duty.
- Ability to open the menu for the player instead ( if they trust enough a player, or admin_lvl1 ) using : /tpmenu "playerid"
- Excuse my lack of experience but I have no idea how to add a file to Github, so you must do it if you are interested in the script.
Must have : http://pastebin.com/LYDnC5kV ( TMenuCore.pwn ) in the folder : "SS/Core/Admin/TMenuCore.pwn"
