### PR TITLE
Fixed /vsave

### DIFF
--- a/gamemodes/SS/Core/Admin/PlayerList.pwn
+++ b/gamemodes/SS/Core/Admin/PlayerList.pwn
@@ -97,9 +97,10 @@ GetPlayerInfo(name[])
 		warnings,
 		aimshout[128],
 		hash[41],
-		active;
+		active,
+		vSave;
 
-	GetAccountData(name, pass, ipv4, alive, karma, regdate, lastlog, spawntime, totalspawns, warnings, aimshout, hash, active);
+	GetAccountData(name, pass, ipv4, alive, karma, regdate, lastlog, spawntime, totalspawns, warnings, aimshout, hash, active, vSave);
 
 	dayslived = (gettime() > spawntime) ? (0) : ((gettime() - spawntime) / 86400);
 

--- a/gamemodes/SS/Core/Vehicle/PlayerVehicle.pwn
+++ b/gamemodes/SS/Core/Vehicle/PlayerVehicle.pwn
@@ -308,7 +308,7 @@ LoadPlayerVehicle(filename[])
 				itemlist;
 
 			length = modio_read(filepath, _T<T,T,R,N>, sizeof(vehicle_ItemList), vehicle_ItemList, false, false);
-		
+
 			itemlist = ExtractItemList(vehicle_ItemList, length);
 			itemcount = GetItemListItemCount(itemlist);
 
@@ -643,7 +643,7 @@ public OnVehicleDestroyed(vehicleid)
 #else
 	#define _ALS_OnVehicleDestroyed
 #endif
- 
+
 #define OnVehicleDestroyed pveh_OnVehicleDestroyed
 #if defined pveh_OnVehicleDestroyed
 	forward pveh_OnVehicleDestroyed(vehicleid);
@@ -832,9 +832,15 @@ stock RemoveVehicleFile(vehicleid)
 
 CMD:vsave(playerid, params[])
 {
+	new
+		name[MAX_PLAYER_NAME];
+
+    GetPlayerName(playerid, name, MAX_PLAYER_NAME);
+
 	if(!isnull(params) && !strcmp(params, "on"))
 	{
 		pveh_SaveAnyVehicle[playerid] = 1;
+		SetAccountVSaveState(name, pveh_SaveAnyVehicle[playerid]);
 		Msg(playerid, YELLOW, " >  Vehicle save mode set to 'All vehicles'. When you enter ANY vehicle, it will be saved for you.");
 		return 1;
 	}
@@ -842,6 +848,7 @@ CMD:vsave(playerid, params[])
 	if(!isnull(params) && !strcmp(params, "off"))
 	{
 		pveh_SaveAnyVehicle[playerid] = 0;
+		SetAccountVSaveState(name, pveh_SaveAnyVehicle[playerid]);
 		Msg(playerid, YELLOW, " >  Vehicle save mode set to: 'Own vehicle'. Only your own vehicle will be saved when you drive it. If you enter another vehicle as a driver, it won't overwrite your current vehicle.");
 		return 1;
 	}


### PR DESCRIPTION
Fixed the problem with the /vsave command. When you crashed or reloged
the server did not save the option you set with /vsave.
It was annoying, because if you set /vsave to off, and you leave your
vehicle at base then you crash far away from base the /vsave set itself
to on, after you join. So you couldn't save the vehicle at your base, if
you entered another one.

I am using MySQL R39 for saving, and I haven't used SQLite, so there
might be mistakes in the code. And also i could not test it, because the
compiler crashes for me.

Note: If you merge this, you have to alter the table.