### PR TITLE
Revert CancelPlayerMovement removal from vehicle entry anti-desync

### DIFF
--- a/gamemodes/sss/core/player/core.pwn
+++ b/gamemodes/sss/core/player/core.pwn
@@ -476,7 +476,7 @@ hook OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
 		return 0;
 
 	if(GetPlayerSurfingVehicleID(playerid) == vehicleid)
-		ClearAnimations(playerid);
+		CancelPlayerMovement(playerid);
 
 	if(ispassenger)
 	{
@@ -494,7 +494,7 @@ hook OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
 		}
 
 		if(driverid == -1)
-			ClearAnimations(playerid);
+			CancelPlayerMovement(playerid);
 	}
 
 	return 1;

--- a/gamemodes/sss/core/vehicle/lock.pwn
+++ b/gamemodes/sss/core/vehicle/lock.pwn
@@ -89,7 +89,7 @@ hook OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
 {
 	if(lock_Status[vehicleid])
 	{
-		ClearAnimations(playerid);
+		CancelPlayerMovement(playerid);
 		ShowActionText(playerid, "Door Locked", 3000);
 	}
 


### PR DESCRIPTION
Reverts Southclaw/ScavengeSurvive#196
Will fix by implementing Kar's SetPlayerSkin fix.