### PR TITLE
Knockout, and vehicle entering fix

### DIFF
--- a/gamemodes/sss/core/char/knockout.pwn
+++ b/gamemodes/sss/core/char/knockout.pwn
@@ -87,7 +87,6 @@ stock KnockOutPlayer(playerid, duration)
 
 	printf("[KNOCKOUT] Player %p knocked out for %s", playerid, MsToString(duration, "%1m:%1s.%1d"));
 
-	ShowPlayerProgressBar(playerid, KnockoutBar);
 
 	if(IsPlayerInAnyVehicle(playerid))
 	{
@@ -101,6 +100,9 @@ stock KnockOutPlayer(playerid, duration)
 	}
 	else
 	{
+	    ShowPlayerProgressBar(playerid, KnockoutBar);
+		SetPlayerProgressBarValue(playerid, KnockoutBar, 0.0);
+	
 		knockout_Tick[playerid] = GetTickCount();
 		knockout_Duration[playerid] = duration;
 		knockout_KnockedOut[playerid] = true;
@@ -115,6 +117,8 @@ stock KnockOutPlayer(playerid, duration)
 
 	if(knockout_Duration[playerid] > knockout_MaxDuration)
 		knockout_Duration[playerid] = knockout_MaxDuration;
+
+	SetPlayerProgressBarMaxValue(playerid, KnockoutBar, knockout_Duration[playerid]);
 
 	CallLocalFunction("OnPlayerKnockOut", "d", playerid);
 
@@ -183,7 +187,7 @@ timer KnockOutUpdate[100](playerid)
 	}
 
 	SetPlayerProgressBarValue(playerid, KnockoutBar, GetTickCountDifference(GetTickCount(), knockout_Tick[playerid]));
-	SetPlayerProgressBarMaxValue(playerid, KnockoutBar, knockout_Duration[playerid]);
+	ShowPlayerProgressBar(playerid, KnockoutBar);
 
 	//ShowActionText(playerid, sprintf("%s/%s", MsToString(GetTickCountDifference(GetTickCount(), knockout_Tick[playerid]), "%1m:%1s.%1d"), MsToString(knockout_Duration[playerid], "%1m:%1s.%1d")));
 

--- a/gamemodes/sss/core/vehicle/lock.pwn
+++ b/gamemodes/sss/core/vehicle/lock.pwn
@@ -28,7 +28,7 @@
 static
 	lock_Status				[MAX_VEHICLES],
 	lock_LastChange			[MAX_VEHICLES],
-	lock_DisableForPlayer	[MAX_PLAYERS];
+	lock_EnableForPlayer	[MAX_PLAYERS] = {true, ...};
 
 
 hook OnVehicleCreated(vehicleid)
@@ -45,7 +45,7 @@ hook OnPlayerConnect(playerid)
 {
 	d:3:GLOBAL_DEBUG("[OnPlayerConnect] in /gamemodes/sss/core/vehicle/lock.pwn");
 
-	lock_DisableForPlayer[playerid] = false;
+	lock_EnableForPlayer[playerid] = true;
 }
 
 hook OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
@@ -94,7 +94,7 @@ hook OnPlayerEnterVehArea(playerid, vehicleid)
 {
 	d:3:GLOBAL_DEBUG("[OnPlayerEnterVehArea] in /gamemodes/sss/core/vehicle/lock.pwn");
 
-	if(!lock_Status[vehicleid] && !lock_DisableForPlayer[playerid])
+	if(!lock_Status[vehicleid] && lock_EnableForPlayer[playerid])
 	{
 		SetVehicleParamsForPlayer(vehicleid, playerid, 0, 0);
 	}
@@ -164,7 +164,7 @@ stock TogglePlayerVehicleEntry(playerid, bool:toggle)
 	if(!IsPlayerConnected(playerid))
 		return 0;
 
-	lock_DisableForPlayer[playerid] = toggle;
+	lock_EnableForPlayer[playerid] = toggle;
 
 	return 1;
 }


### PR DESCRIPTION
Fixed the vehicle entering bug, which prevented the players to enter
vehicles.
I also fixed the knockout bug, where the progressbar did not move, while
you were knocked out.