### PR TITLE
Quick supply drop fix

### DIFF
--- a/gamemodes/sss/core/server/init.pwn
+++ b/gamemodes/sss/core/server/init.pwn
@@ -1531,14 +1531,6 @@ public OnScriptInit()
 	DefineBagType("Love Box",			item_HeartShapedBox,6, 0.121852, -0.110032, -0.009413,  0.000000, 90.000000, 0.000000, 1.000000, 1.000000, 1.000000);
 
 
-	// SUPPLY DROP TYPE DEFINITIONS
-	DefineSupplyDropType("Food and Medical",	loot_FoodMedCrate,	900,	600,	3);
-	DefineSupplyDropType("Low Grade Weapons",	loot_LowWepCrate,	2400,	1200,	4);
-	DefineSupplyDropType("Military Weapons",	loot_MilWepCrate,	4200,	1800,	6);
-	DefineSupplyDropType("Industrial Supplies",	loot_IndustCrate,	2000,	900,	5);
-	DefineSupplyDropType("Ordnance Supplies",	loot_OrdnanceCrate,	10800,	10800,	8);
-
-
 	// SEED TYPE DEFINITIONS
 	DefineSeedType("Tomato", item_Tomato,	4, 631, 0.90649);
 	DefineSeedType("Apple", item_RedApple,	5, 802, 0.72044);
@@ -1614,6 +1606,14 @@ public OnScriptInit()
 	loot_MilWepCrate	= DefineLootIndex("scmw");
 	loot_IndustCrate	= DefineLootIndex("scin");
 	loot_OrdnanceCrate	= DefineLootIndex("scor");
+
+
+    // SUPPLY DROP TYPE DEFINITIONS
+	DefineSupplyDropType("Food and Medical",	loot_FoodMedCrate,	900,	600,	3);
+	DefineSupplyDropType("Low Grade Weapons",	loot_LowWepCrate,	2400,	1200,	4);
+	DefineSupplyDropType("Military Weapons",	loot_MilWepCrate,	4200,	1800,	6);
+	DefineSupplyDropType("Industrial Supplies",	loot_IndustCrate,	2000,	900,	5);
+	DefineSupplyDropType("Ordnance Supplies",	loot_OrdnanceCrate,	10800,	10800,	8);
 
 
 	// SKIN DEFINITIONS

--- a/gamemodes/sss/core/world/workbench.pwn
+++ b/gamemodes/sss/core/world/workbench.pwn
@@ -185,7 +185,27 @@ _wb_PlayerUseWorkbench(playerid, workbenchid, itemid)
 		if(GetItemType(itemid) == GetConstructionSetTool(consset))
 		{
 			d:2:HANDLER("[_wb_PlayerUseWorkbench] craftset determined and tool matched, start building...");
+
+			new
+				Float:x,
+				Float:y,
+				Float:z;
 	
+			GetPlayerPos(playerid, x, y, z);
+			SetPlayerFacingAngle(playerid, GetAngleToPoint(x, y, wb_Data[workbenchid][wb_posX],  wb_Data[workbenchid][wb_posY]));
+	
+			ApplyAnimation(playerid, "INT_SHOP", "SHOP_CASHIER", 4.0, 1, 0, 0, 0, 0, 1);
+
+			new
+				Float:x,
+				Float:y,
+				Float:z;
+
+			GetPlayerPos(playerid, x, y, z);
+			SetPlayerFacingAngle(playerid, GetAngleToPoint(x, y, wb_Data[workbenchid][wb_posX],  wb_Data[workbenchid][wb_posY]));
+
+			ApplyAnimation(playerid, "INT_SHOP", "SHOP_CASHIER", 4.0, 1, 0, 0, 0, 0, 1);
+
 			StartHoldAction(playerid, GetConstructionSetBuildTime(consset));
 			wb_CurrentWorkbench[playerid] = workbenchid;
 			wb_CurrentConstructSet[playerid] = consset;
@@ -323,6 +343,8 @@ hook OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 		if(wb_CurrentWorkbench[playerid] != -1)
 		{
 			d:1:HANDLER("[OnPlayerKeyStateChange] stopping workbench build");
+
+			ClearAnimations(playerid);
 
 			StopHoldAction(playerid);
 			wb_CurrentWorkbench[playerid] = -1;


### PR DESCRIPTION
Loot indexes were defined after DefineSupplyDropType() so it's
"lootindex" paramter was 0, which resulted adding civilian items only to
the box.

Also added the vehicle repairing animation to workbenches to make the
crafting look more realistic.