### PR TITLE
Workbench and vehilce fix

### DIFF
--- a/gamemodes/ScavengeSurvive.pwn
+++ b/gamemodes/ScavengeSurvive.pwn
@@ -431,6 +431,9 @@ new stock
 	CHILD SYSTEMS
 	Modules that do not declare anything globally accessible besides interfaces.
 */
+// GAME DATA LOADING
+#include "sss/data/loot.pwn" // todo: load from file
+
 // VEHICLE
 #include "sss/core/vehicle/player-vehicle.pwn"
 #include "sss/core/vehicle/loot-vehicle.pwn"
@@ -605,9 +608,6 @@ new stock
 #include "sss/core/item/heartshapedbox.pwn"
 #include "sss/core/item/fishingrod.pwn"
 #include "sss/core/item/chainsaw.pwn"
-
-// GAME DATA LOADING
-#include "sss/data/loot.pwn" // todo: load from file
 
 
 // POST-CODE

--- a/gamemodes/sss/core/world/workbench.pwn
+++ b/gamemodes/sss/core/world/workbench.pwn
@@ -84,6 +84,15 @@ hook OnPlayerConnect(playerid)
 	wb_CurrentWorkbench[playerid] = -1;
 }
 
+<<<<<<< HEAD
+=======
+hook OnPlayerDisconnect(playerid, reason)
+{
+	if(wb_CurrentWorkbench[playerid] != -1)
+		_wb_StopWorking(playerid);
+}
+
+>>>>>>> aef432d... Workbench and vehilce fix
 
 /*==============================================================================
 
@@ -354,6 +363,7 @@ hook OnHoldActionFinish(playerid)
 
 		_wb_ClearWorkbench(wb_CurrentWorkbench[playerid]);
 		_wb_CreateResult(wb_CurrentWorkbench[playerid], GetConstructionSetCraftSet(wb_CurrentConstructSet[playerid]));
+		_wb_StopWorking(playerid);
 		wb_CurrentWorkbench[playerid] = -1;
 		wb_CurrentConstructSet[playerid] = -1;
 	}

--- a/gamemodes/sss/core/world/workbench.pwn
+++ b/gamemodes/sss/core/world/workbench.pwn
@@ -84,15 +84,12 @@ hook OnPlayerConnect(playerid)
 	wb_CurrentWorkbench[playerid] = -1;
 }
 
-<<<<<<< HEAD
-=======
 hook OnPlayerDisconnect(playerid, reason)
 {
 	if(wb_CurrentWorkbench[playerid] != -1)
 		_wb_StopWorking(playerid);
 }
 
->>>>>>> aef432d... Workbench and vehilce fix
 
 /*==============================================================================
 


### PR DESCRIPTION
Fixed when you couldn't remove item from workbench.
Fixed error, when you logged out without using the workbench.
Fixed vehicles spawning with empty trunk.