### PR TITLE
Bugfixes + added labels to fuel outlets

### DIFF
--- a/gamemodes/sss/core/char/infection.pwn
+++ b/gamemodes/sss/core/char/infection.pwn
@@ -48,6 +48,14 @@ hook OnPlayerConnect(playerid)
 	return 1;
 }
 
+hook OnPlayerDeath(playerid, killerid, reason)
+{
+	d:3:GLOBAL_DEBUG("[OnPlayerDeath] in /gamemodes/sss/core/char/infection.pwn");
+
+	infect_InfectionIntensity[playerid][0] = 0;
+	infect_InfectionIntensity[playerid][1] = 0;
+	infect_LastShake[playerid] = 0;
+}
 
 //ptask PlayerInfectionUpdate[1000](playerid)
 stock PlayerInfectionUpdate(playerid)

--- a/gamemodes/sss/core/item/shield.pwn
+++ b/gamemodes/sss/core/item/shield.pwn
@@ -50,8 +50,13 @@ timer shield_Down[400](playerid, itemid)
 	GetPlayerFacingAngle(playerid, angle);
 
 	RemoveCurrentItem(playerid);
-	SetItemPos(itemid, x + (0.5 * floatsin(-angle, degrees)), y + (0.5 * floatcos(-angle, degrees)), z - 0.2);
-	SetItemRot(itemid, 90.0, 0.0, 180.0 + angle);
+
+	CreateItemInWorld(itemid,
+		x + (0.5 * floatsin(-angle, degrees)),
+		y + (0.5 * floatcos(-angle, degrees)),
+		z - 0.2,
+		90.0, 0.0, 180.0 + angle,
+		FLOOR_OFFSET, GetPlayerVirtualWorld(playerid), GetPlayerInterior(playerid), 1);
 }
 
 hook OnPlayerShootPlayer(playerid, targetid, bodypart, Float:bleedrate, Float:knockmult, Float:bulletvelocity, Float:distance)

--- a/gamemodes/sss/core/server/init.pwn
+++ b/gamemodes/sss/core/server/init.pwn
@@ -1718,9 +1718,9 @@ public OnScriptInit()
 	DefineTreeSpecies(719, 5.0, 2600.0, 20.0, 30, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log, -1.4);
 	DefineTreeSpecies(720, 5.0, 2600.0, 18.0, 30, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(721, 6.0, 3000.0, 18.0, 38, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log, -3.2);
-	DefineTreeSpecies(722, 5.0, 2600.0, 22.0, 28, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log, -2.2);
+	//DefineTreeSpecies(722, 5.0, 2600.0, 22.0, 28, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log, -2.2);
 	DefineTreeSpecies(723, 5.0, 2500.0, 22.0, 28, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log, 6.0);
-	DefineTreeSpecies(724, 5.0, 2600.0, 18.0, 30, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(724, 5.0, 2600.0, 18.0, 30, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(725, 5.0, 2600.0, 18.0, 30, tree_DarkForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(881, 1.0, 600.0, 25.0, 7, tree_DarkForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 
@@ -1731,7 +1731,7 @@ public OnScriptInit()
 	DefineTreeSpecies(656, 2.5, 1100.0, 25.0, 16, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(657, 2.0, 750.0, 25.0, 8, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(658, 2.0, 1200.0, 25.0, 14, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
-	DefineTreeSpecies(661, 2.0, 850.0, 25.0, 12, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(661, 2.0, 850.0, 25.0, 12, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(726, 2.0, 1700.0, 25.0, 16, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(727, 2.0, 900.0, 25.0, 14, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(729, 2.0, 900.0, 25.0, 14, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
@@ -1748,21 +1748,21 @@ public OnScriptInit()
 	DefineTreeSpecies(770, 1.5, 800.0, 28.0, 8, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(771, 2.0, 1000.0, 25.0, 14, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(779, 1.5, 700.0, 30.0, 6, tree_LightForest, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
-	DefineTreeSpecies(882, 2.0, 700.0, 25.0, 8, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(883, 2.0, 600.0, 25.0, 8, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(884, 2.0, 600.0, 25.0, 6, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(885, 2.0, 650.0, 25.0, 6, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(882, 2.0, 700.0, 25.0, 8, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(883, 2.0, 600.0, 25.0, 8, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(884, 2.0, 600.0, 25.0, 6, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(885, 2.0, 650.0, 25.0, 6, tree_LightForest, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 
-	DefineTreeSpecies(629, 1.0, 400.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(629, 1.0, 400.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(674, 1.0, 500.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(676, 1.0, 400.0, 25.0, 2, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(680, 1.0, 500.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(681, 1.0, 400.0, 25.0, 2, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	DefineTreeSpecies(773, 1.0, 650.0, 30.0, 8, tree_Desert, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
-	DefineTreeSpecies(891, 1.0, 400.0, 30.0, 5, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(904, 1.0, 300.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(891, 1.0, 400.0, 30.0, 5, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(904, 1.0, 300.0, 25.0, 3, tree_Desert, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 	// cacti
-	DefineTreeSpecies(650, 1.0, 600.0, 28.0, 1, tree_Desert, FALL_TYPE_ROTATE, item_Knife, item_CakeSlice);
+	//DefineTreeSpecies(650, 1.0, 600.0, 28.0, 1, tree_Desert, FALL_TYPE_ROTATE, item_Knife, item_CakeSlice);
 	DefineTreeSpecies(651, 1.0, 600.0, 28.0, 1, tree_Desert, FALL_TYPE_ROTATE, item_Knife, item_CakeSlice);
 
 	DefineTreeSpecies(669, 2.5, 1200.0, 25.0, 14, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
@@ -1786,9 +1786,9 @@ public OnScriptInit()
 	DefineTreeSpecies(780, 1.5, 800.0, 25.0, 8, tree_GrassPlanes, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(781, 1.0, 650.0, 25.0, 4, tree_GrassPlanes, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
 	DefineTreeSpecies(782, 1.5, 800.0, 25.0, 6, tree_GrassPlanes, FALL_TYPE_ROTATE, item_Chainsaw, item_Log);
-	DefineTreeSpecies(886, 1.0, 800.0, 25.0, 5, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(887, 1.5, 800.0, 25.0, 6, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
-	DefineTreeSpecies(888, 1.0, 600.0, 25.0, 4, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(886, 1.0, 800.0, 25.0, 5, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(887, 1.5, 800.0, 25.0, 6, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
+	//DefineTreeSpecies(888, 1.0, 600.0, 25.0, 4, tree_GrassPlanes, FALL_TYPE_ZDROP, item_Chainsaw, item_Log);
 
 	/*
 		VEHICLE GROUP AND TYPE DEFINITIONS	

--- a/gamemodes/sss/core/ui/key-actions.pwn
+++ b/gamemodes/sss/core/ui/key-actions.pwn
@@ -154,10 +154,6 @@ ptask ToolTipUpdate[1000](playerid)
 			if(IsPlayerAtVehicleBonnet(playerid, invehiclearea))
 				AddToolTipText(playerid, KEYTEXT_INTERACT, "Refuel vehicle");
 		}
-		else if(IsPlayerAtAnyFuelOutlet(playerid))
-		{
-			AddToolTipText(playerid, KEYTEXT_INTERACT, "Fill fuel can");
-		}
 	}
 	else if(itemtype == item_Clothes)
 	{


### PR DESCRIPTION
Added to reset the infection, when the player dies
Fixed shield drop
Uncommented the bugged tree models (most of them can be breaked if you
ram it with a vehicle, maybe we can fix it later with invisible objects)
Added labels to fuel outlets, and they use button now - #243, #242 