### PR TITLE
Liquid container fix

### DIFF
--- a/gamemodes/sss/core/item/liquid-container.pwn
+++ b/gamemodes/sss/core/item/liquid-container.pwn
@@ -126,7 +126,7 @@ hook OnItemCreateInWorld(itemid)
 
 			if(size > 0)
 			{
-				SetItemArrayDataAtCell(itemid, _:liq_Data[liqcont][liq_capacity], LIQUID_ITEM_ARRAY_CELL_AMOUNT);
+				SetItemArrayDataAtCell(itemid, _:frandom(liq_Data[liqcont][liq_capacity]), LIQUID_ITEM_ARRAY_CELL_AMOUNT);
 				SetItemArrayDataAtCell(itemid, liqlist[random(size)], LIQUID_ITEM_ARRAY_CELL_TYPE);
 			}
 		}

--- a/gamemodes/sss/core/item/molotov.pwn
+++ b/gamemodes/sss/core/item/molotov.pwn
@@ -26,30 +26,47 @@ hook OnPlayerUseItemWithItem(playerid, itemid, withitemid)
 {
 	d:3:GLOBAL_DEBUG("[OnPlayerUseItemWithItem] in /gamemodes/sss/core/item/molotov.pwn");
 
-	if(GetItemType(itemid) == item_GasCan && GetItemType(withitemid) == item_MolotovEmpty)
+	if(GetItemType(withitemid) == item_MolotovEmpty)
 	{
-		if(GetItemExtraData(itemid) > 0)
+		new 
+			ItemType:itemtype = GetItemType(itemid);
+
+		if(GetItemTypeLiquidContainerType(itemtype) == -1)
+			return Y_HOOKS_BREAK_RETURN_1;
+			
+		if(GetLiquidItemLiquidType(itemid) != liquid_Petrol)
 		{
-			new
-				Float:x,
-				Float:y,
-				Float:z,
-				Float:rz;
-
-			GetItemPos(withitemid, x, y, z);
-			GetItemRot(withitemid, rz, rz, rz);
-
-			DestroyItem(withitemid);
-			CreateItem(ItemType:18, x, y, z, .rz = rz, .zoffset = FLOOR_OFFSET);
-
-			ApplyAnimation(playerid, "BOMBER", "BOM_PLANT_IN", 4.0, 0, 0, 0, 0, 0);
-			ShowActionText(playerid, ls(playerid, "MOLOPOURBOT"), 3000);
-			SetItemExtraData(itemid, GetItemExtraData(itemid) - 1);
+			ShowActionText(playerid, ls(playerid, "FUELNOTPETR"), 3000);
+			return Y_HOOKS_BREAK_RETURN_1;
 		}
-		else
+
+		new 
+			Float:canfuel = GetLiquidItemLiquidAmount(itemid);
+
+		if(canfuel <= 0.0)
 		{
 			ShowActionText(playerid, ls(playerid, "PETROLEMPTY"), 3000);
+			return Y_HOOKS_BREAK_RETURN_1;
 		}
+
+		new
+			Float:x,
+			Float:y,
+			Float:z,
+			Float:rz,
+			Float:transfer;
+
+		GetItemPos(withitemid, x, y, z);
+		GetItemRot(withitemid, rz, rz, rz);
+
+		DestroyItem(withitemid);
+		CreateItem(ItemType:18, x, y, z, .rz = rz, .zoffset = FLOOR_OFFSET);
+
+		ApplyAnimation(playerid, "BOMBER", "BOM_PLANT_IN", 4.0, 0, 0, 0, 0, 0);
+		ShowActionText(playerid, ls(playerid, "MOLOPOURBOT"), 3000);
+		
+		transfer = (canfuel - 0.5 < 0.0) ? canfuel : 0.5;
+		SetLiquidItemLiquidAmount(itemid, canfuel - transfer);
 	}
 
 	return Y_HOOKS_CONTINUE_RETURN_0;

--- a/gamemodes/sss/core/world/barbecue.pwn
+++ b/gamemodes/sss/core/world/barbecue.pwn
@@ -129,13 +129,25 @@ _UseBbqHandler(playerid, itemid, withitemid)
 
 	new ItemType:itemtype = GetItemType(itemid);
 
-	if(itemtype == item_GasCan)
+	if(GetItemTypeLiquidContainerType(itemtype) != -1)
 	{
 		d:2:HANDLER("[_UseBbqHandler] Item type is gas can", playerid, itemid, withitemid);
-		if(GetItemExtraData(itemid) > 0)
+
+		if(GetLiquidItemLiquidType(itemid) != liquid_Petrol)
 		{
+			ShowActionText(playerid, ls(playerid, "FUELNOTPETR"), 3000);
+			return 1;
+		}
+
+		new 
+			Float:canfuel = GetLiquidItemLiquidAmount(itemid),
+			Float:transfer;
+
+		if(canfuel > 0.0)
+		{
+			transfer = (canfuel - 0.6 < 0.0) ? canfuel : 0.6;
+			SetLiquidItemLiquidAmount(itemid, canfuel - transfer);
 			SetItemArrayDataAtCell(withitemid, data[bbq_fuel] + 10, bbq_fuel);
-			SetItemExtraData(itemid, GetItemExtraData(itemid) - 1);
 			ShowActionText(playerid, ls(playerid, "BBQADDPETRO"), 3000);
 		}
 		else

--- a/gamemodes/sss/core/world/campfire.pwn
+++ b/gamemodes/sss/core/world/campfire.pwn
@@ -254,20 +254,33 @@ hook OnPlayerUseItemWithItem(playerid, itemid, withitemid)
 		{
 			if(!IsValidDynamicObject(cmp_Data[fireid][cmp_objFlame]))
 			{
+
 				new ItemType:itemtype = GetItemType(itemid);
 
-				if(itemtype == item_GasCan)
+				if(GetItemTypeLiquidContainerType(itemtype) != -1)
 				{
+					if(GetLiquidItemLiquidType(itemid) != liquid_Petrol)
+					{
+						ShowActionText(playerid, ls(playerid, "FUELNOTPETR"), 3000);
+						return 1;
+					}
+
+					new 
+						Float:canfuel = GetLiquidItemLiquidAmount(itemid),
+						Float:transfer;
+
+
 					if(cmp_Data[fireid][cmp_fueled])
 					{
 						ShowActionText(playerid, ls(playerid, "FIREALREADY"));
 					}
 					else
 					{
-						if(GetItemExtraData(itemid) > 0)
+						if(canfuel > 0.0)
 						{
+							transfer = (canfuel - 0.3 < 0.0) ? canfuel : 0.3;
+							SetLiquidItemLiquidAmount(itemid, canfuel - transfer);
 							ShowActionText(playerid, ls(playerid, "FIREADDPETR"));
-							SetItemExtraData(itemid, GetItemExtraData(itemid) - 1);
 							cmp_Data[fireid][cmp_fueled] = 1;
 						}
 						else

--- a/gamemodes/sss/core/world/fuel.pwn
+++ b/gamemodes/sss/core/world/fuel.pwn
@@ -25,7 +25,7 @@
 #include <YSI\y_hooks>
 
 #define INVALID_FUEL_OUTLET_ID	(-1)
-#define MAX_FUEL_LOCATIONS		(78)
+#define MAX_FUEL_LOCATIONS		(86)
 
 
 enum E_FUEL_DATA

--- a/gamemodes/sss/core/world/scrap-machine.pwn
+++ b/gamemodes/sss/core/world/scrap-machine.pwn
@@ -163,11 +163,17 @@ _sm_PlayerUseScrapMachine(playerid, scrapmachineid, interactiontype)
 
 	sm_CurrentScrapMachine[playerid] = scrapmachineid;
 
-	if(GetItemType(GetPlayerItem(playerid)) == item_GasCan)
+	new 
+		ItemType:itemtype = GetItemType(GetPlayerItem(playerid));
+
+	if(GetItemTypeLiquidContainerType(itemtype) != -1)
 	{
-		d:1:HANDLER("[_sm_PlayerUseScrapMachine] starting HoldAction for %ds starting at %ds", floatround(MAX_SCRAP_MACHINE_FUEL), floatround(sm_Data[scrapmachineid][sm_fuel]));
-		StartHoldAction(playerid, floatround(MAX_SCRAP_MACHINE_FUEL * 1000), floatround(sm_Data[scrapmachineid][sm_fuel] * 1000));
-		return 0;
+		if(GetLiquidItemLiquidType(GetPlayerItem(playerid)) == liquid_Petrol)
+		{
+			d:1:HANDLER("[_sm_PlayerUseScrapMachine] starting HoldAction for %ds starting at %ds", floatround(MAX_SCRAP_MACHINE_FUEL), floatround(sm_Data[scrapmachineid][sm_fuel]));
+			StartHoldAction(playerid, floatround(MAX_SCRAP_MACHINE_FUEL * 1000), floatround(sm_Data[scrapmachineid][sm_fuel] * 1000));
+			return 0;
+		}
 	}
 
 	inline Response(pid, dialogid, response, listitem, string:inputtext[])
@@ -208,16 +214,22 @@ hook OnHoldActionUpdate(playerid, progress)
 
 		new itemid = GetPlayerItem(playerid);
 
-		if(GetItemType(itemid) != item_GasCan)
+		if(GetItemTypeLiquidContainerType(GetItemType(itemid)) != -1)
 		{
-			d:3:HANDLER("[OnHoldActionUpdate] Stopping HoldAction: player not holding petrol can");
-			StopHoldAction(playerid);
-			sm_CurrentScrapMachine[playerid] = -1;
+			if(GetLiquidItemLiquidType(itemid) != liquid_Petrol)
+			{
+				d:3:HANDLER("[OnHoldActionUpdate] Stopping HoldAction: player not holding petrol can");
+				StopHoldAction(playerid);
+				sm_CurrentScrapMachine[playerid] = -1;
+				return Y_HOOKS_BREAK_RETURN_1;
+			}
 		}
 
-		new fuel = GetItemArrayDataAtCell(itemid, 0);
+		new 
+			Float:fuel = GetLiquidItemLiquidAmount(itemid),
+			Float:transfer;
 
-		if(fuel <= 0)
+		if(fuel <= 0.0)
 		{
 			d:3:HANDLER("[OnHoldActionUpdate] Stopping HoldAction: petrol can has %d < 0 fuel", fuel);
 			StopHoldAction(playerid);
@@ -227,8 +239,9 @@ hook OnHoldActionUpdate(playerid, progress)
 		else
 		{
 			d:3:HANDLER("[OnHoldActionUpdate] setting petrol can to %d, machine to %.1f", fuel - 1, sm_Data[sm_CurrentScrapMachine[playerid]][sm_fuel] + 1.0);
-			SetItemArrayDataAtCell(itemid, fuel - 1, 0);
-			sm_Data[sm_CurrentScrapMachine[playerid]][sm_fuel] += 1.0;
+			transfer = (fuel - 1.1 < 0.0) ? fuel : 1.1;
+			SetLiquidItemLiquidAmount(itemid, fuel - transfer);
+			sm_Data[sm_CurrentScrapMachine[playerid]][sm_fuel] += 1.1;
 			ShowActionText(playerid, ls(playerid, "REFUELLING"));
 		}
 	}


### PR DESCRIPTION
Liquid containers are now spawns with a random value of liquid in it.
Implemented liquid containers to items which used fuel (code might needs
to be simplified).
Increased MAX_FUEL_LOCATIONS's value, because there was one fuel outlet
which could not be created.