### PR TITLE
Typo fix

### DIFF
--- a/gamemodes/sss/core/player/accounts.pwn
+++ b/gamemodes/sss/core/player/accounts.pwn
@@ -357,7 +357,7 @@ CreateAccount(playerid, password[])
 DisplayRegisterPrompt(playerid)
 {
 	new str[150];
-	format(str, 150, ls(playerid, "ACCREGIBOD"), playerid);
+	format(str, 150, ls(playerid, "ACCREGIBODY"), playerid);
 
 	logf("[REGPROMPT] %p is registering", playerid);
 


### PR DESCRIPTION
Small typo in language string. 
These fixes when new unregistered players could not do anything on join and only saw black screen.